### PR TITLE
Prepare release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the ChaosCanvas extension will be documented in this file
 
 ## [Unreleased]
 
+## [1.0.0]
+
 - Initial implementation of random token coloring
 - Added Toggle Chaos Mode command
 - Added Shuffle Colors command

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chaoscanvas",
   "displayName": "ChaosCanvas",
   "description": "Paints every code token in a random hue, transforming your editor into a living kaleidoscope that adds a playful twist to syntax highlighting.",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "publisher": "kyori19",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release version 1.0.0 of ChaosCanvas extension, featuring initial implementation with random token coloring, Toggle Chaos Mode, and Shuffle Colors commands. Updated CHANGELOG and package.json to reflect the new version.